### PR TITLE
pub AxumConnectServiceGenerator

### DIFF
--- a/axum-connect-build/src/lib.rs
+++ b/axum-connect-build/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
     rc::Rc,
 };
 
-use gen::AxumConnectServiceGenerator;
+pub use gen::AxumConnectServiceGenerator;
 
 mod gen;
 
@@ -105,7 +105,10 @@ pub fn axum_connect_codegen(settings: AxumConnectGenSettings) -> anyhow::Result<
             output.set_file_name(format!("{}.rs", package));
             files_c.deref().borrow_mut().push(output.clone());
 
-            let file = std::fs::OpenOptions::new().append(true).create(true).open(&output)?;
+            let file = std::fs::OpenOptions::new()
+                .append(true)
+                .create(true)
+                .open(&output)?;
 
             Ok(BufWriter::new(file))
         })?;


### PR DESCRIPTION
Hi @AThilenius 

It is not complicated to use `AxumConnectServiceGenerator` directly, I think we can pub it.
Please review it. thank you.

```
use std::{env, fs, path::PathBuf};

use axum_connect_build::AxumConnectServiceGenerator;

//
fn main() -> Result<(), Box<dyn std::error::Error>> {
    let descriptor_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("proto_descriptor.bin");

    prost_build::Config::new()
        .file_descriptor_set_path(&descriptor_path)
        .compile_well_known_types()
        .extern_path(".google.protobuf", "::pbjson_types")
        .service_generator(Box::new(AxumConnectServiceGenerator {})).compile_protos(
            &[
                "../xxx.proto",
            ],
            &[".."],
        )?;

    let descriptor_set = fs::read(descriptor_path)?;
    pbjson_build::Builder::new()
        .register_descriptors(&descriptor_set)?
        .build(&[".xxx",])?;

    Ok(())
}
```
