### PR TITLE
fix: server streaming protocol encoding

### DIFF
--- a/axum-connect/src/handler/handler_stream.rs
+++ b/axum-connect/src/handler/handler_stream.rs
@@ -85,7 +85,7 @@ pub trait RpcHandlerStream<TMReq, TMRes, TUid, TState>:
 //                     match rpc_item {
 //                         Ok(rpc_item) => {
 //                             if binary {
-//                                 let mut res = vec![0x2, 0, 0, 0, 0];
+//                                 let mut res = vec![0, 0, 0, 0, 0];
 //                                 if let Err(e) = rpc_item.encode(&mut res) {
 //                                     let e = RpcError::new(RpcErrorCode::Internal, e.to_string());
 //                                     yield Result::<Vec<u8>, Infallible>::Ok(encode_error(&e, true));
@@ -95,7 +95,7 @@ pub trait RpcHandlerStream<TMReq, TMRes, TUid, TState>:
 //                                 res[1..5].copy_from_slice(&size);
 //                                 yield Ok(res);
 //                             } else {
-//                                 let mut res = vec![0x2, 0, 0, 0, 0];
+//                                 let mut res = vec![0, 0, 0, 0, 0];
 //                                 if let Err(e) = serde_json::to_writer(&mut res, &rpc_item) {
 //                                     let e = RpcError::new(RpcErrorCode::Internal, e.to_string());
 //                                     yield Ok(encode_error(&e, true));
@@ -195,7 +195,7 @@ macro_rules! impl_handler {
                             match rpc_item {
                                 Ok(rpc_item) => {
                                     if binary {
-                                        let mut res = vec![0x2, 0, 0, 0, 0];
+                                        let mut res = vec![0, 0, 0, 0, 0];
                                         if let Err(e) = rpc_item.encode(&mut res) {
                                             let e = RpcError::new(RpcErrorCode::Internal, e.to_string());
                                             yield Result::<Vec<u8>, Infallible>::Ok(encode_error(&e, true));
@@ -205,7 +205,7 @@ macro_rules! impl_handler {
                                         res[1..5].copy_from_slice(&size);
                                         yield Ok(res);
                                     } else {
-                                        let mut res = vec![0x2, 0, 0, 0, 0];
+                                        let mut res = vec![0, 0, 0, 0, 0];
                                         if let Err(e) = serde_json::to_writer(&mut res, &rpc_item) {
                                             let e = RpcError::new(RpcErrorCode::Internal, e.to_string());
                                             yield Ok(encode_error(&e, true));

--- a/axum-connect/src/handler/handler_stream.rs
+++ b/axum-connect/src/handler/handler_stream.rs
@@ -115,11 +115,7 @@ pub trait RpcHandlerStream<TMReq, TMRes, TUid, TState>:
 
 //                 // EndStreamResponse, see: https://connect.build/docs/protocol/#error-end-stream
 //                 // TODO: Support returning trailers (they would need to bundle in the error type).
-//                 if binary {
-//                     yield Result::<Vec<u8>, Infallible>::Ok(vec![0x2, 0, 0, 0, 0]);
-//                 } else {
-//                     yield Result::<Vec<u8>, Infallible>::Ok(vec![0x2, 0, 0, 0, 2, b'{', b'}']);
-//                 }
+//                 yield Result::<Vec<u8>, Infallible>::Ok(vec![0x2, 0, 0, 0, 2, b'{', b'}']);
 //             };
 
 //             (
@@ -225,11 +221,7 @@ macro_rules! impl_handler {
 
                         // EndStreamResponse, see: https://connect.build/docs/protocol/#error-end-stream
                         // TODO: Support returning trailers (they would need to bundle in the error type).
-                        if binary {
-                            yield Result::<Vec<u8>, Infallible>::Ok(vec![0x2, 0, 0, 0, 0]);
-                        } else {
-                            yield Result::<Vec<u8>, Infallible>::Ok(vec![0x2, 0, 0, 0, 2, b'{', b'}']);
-                        }
+                        yield Result::<Vec<u8>, Infallible>::Ok(vec![0x2, 0, 0, 0, 2, b'{', b'}']);
                     };
 
                     (


### PR DESCRIPTION
Hi! Thanks a lot for this crate :heart: 

I had a bit of time to play around with the server-streaming implementation and found a few things that didn't encode quite well enough so connect-es wouldn't talk to it. 

1. As you note in #10, all streaming messages apparently have to be wrapped in en envelope, even if it's a request for server streaming. I didn't go into actually decoding the envelope since all the contents of it (as of current spec) are specific to client-streaming, bidi-streaming or compression.
2. All server streaming messages had the `EndStreamResponse` bit set.
3. Then actual `EndStreamResponse` message apparently has to contain an empty json even while using the binary protocol. The spec is not very clear on this, however the first sentence in the [EndStreamResponse](https://connectrpc.com/docs/protocol/#error-end-stream) section states that "Connect serializes errors and the block of data at the end of each response stream using JSON". I suppose that applies regardless of the content type. At the very least, connect-es expects it and throws an error if the binary message is empty.

Fixes #10 