### PR TITLE
Bump all dep versions, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@ Brings the protobuf-based [Connect-Web RPC
 framework](https://connect.build/docs/introduction) to Rust via idiomatic
 [Axum](https://github.com/tokio-rs/axum).
 
-# Axum Version
-
-- `axum-connect:0.4` works with `axum:0.8`
-- `axum-connect:0.3` works with `axum:0.7`
-- `axum-connect:0.2` works with `axum:0.6`
-
 # Features 🔍
 
 - Integrates into existing Axum HTTP applications seamlessly
@@ -29,16 +23,6 @@ framework](https://connect.build/docs/introduction) to Rust via idiomatic
 - All the other amazing benefits that come with Axum, like the community,
   documentation and performance!
 
-# Caution ⚠️
-
-We use `axum-connect` in production, but I don't kow that anyone with more sense
-does. It's written in Rust which obviously offers some amazing compiler
-guarantees, but it's not well tested or battle-proven yet. Do what you will with
-that information.
-
-Please let me know if you're using `axum-connect`! And open issues if you find a
-bug.
-
 # Getting Started 🤓
 
 _Prior knowledge with [Protobuf](https://github.com/protocolbuffers/protobuf)
@@ -54,8 +38,10 @@ You'll obviously also need `axum` and `tokio`.
 ```sh
 # Note: axum-connect-build will fetch `protoc` for you.
 cargo add --build axum-connect-build
-cargo add axum-connect prost axum
-cargo add tokio --features full
+
+# Both Prost and Axum are version sensitive. I haven't found a good workaround
+# for this yet. PRs welcome!
+cargo add axum-connect tokio prost@0.13 axum@0.8 --features=tokio/full
 ```
 
 ## Protobuf File 🥱
@@ -205,8 +191,17 @@ async fn stream_three_reponses(
 cargo run -p axum-connect-example
 ```
 
-It's Connect RPCs, so you can use the Buf Studio to test things out!
-https://buf.build/studio/athilenius/axum-connect/main/hello.HelloWorldService/SayHello?target=http%3A%2F%2Flocalhost%3A3030
+It's Connect RPCs, so you can use the Buf Studio to test things out! [Buf Studio - Hello RPC](https://buf.build/studio/athilenius/axum-connect/main/hello.HelloWorldService/SayHello?target=http%3A%2F%2Flocalhost%3A3030&share=sxKoVspLzE1VslJQcsxJTVaqBQA)
+
+Or CURL it
+
+```sh
+curl -X POST http://localhost:3030/hello.HelloWorldService/SayHello \
+     -H "Content-Type: application/json" \
+     -d '{"name":"Alec"}'
+```
+
+> {"message":"Hello Alec! You're addressing the hostname: localhost:3030."}
 
 # Request/Response Parts 🙍‍♂️
 

--- a/axum-connect-build/Cargo.toml
+++ b/axum-connect-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-connect-build"
-version = "0.4.2"
+version = "0.5.1"
 authors = ["Alec Thilenius <alec@thilenius.com>"]
 edition = "2021"
 categories = [
@@ -15,13 +15,13 @@ readme = "../README.md"
 repository = "https://github.com/AThilenius/axum-connect"
 
 [dependencies]
-anyhow = "1.0"
-convert_case = "0.6.0"
-pbjson-build = "0.6.2"
-proc-macro2 = "1.0.56"
-prost = "0.12.1"
-prost-build = "0.12.1"
-prost-reflect = "0.12.0"
-protoc-fetcher = "0.1.0"
-quote = "1.0.26"
-syn = "2.0.15"
+anyhow = "1.0.95"
+convert_case = "0.7.1"
+pbjson-build = "0.7.0"
+proc-macro2 = "1.0.93"
+prost = ">=0.13"
+prost-build = "0.13.4"
+prost-reflect = "0.14.5"
+protoc-fetcher = "0.1.1"
+quote = "1.0.38"
+syn = "2.0.96"

--- a/axum-connect-examples/Cargo.toml
+++ b/axum-connect-examples/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "axum-connect-example"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.80"
-async-stream = "0.3.5"
-axum = "0.8.1"
-axum-extra = "0.10.0"
+anyhow = "1.0.95"
+async-stream = "0.3.6"
+axum = "0.8"
 axum-connect = { path = "../axum-connect", features = ["axum-extra"] }
-prost = "0.12.1"
-thiserror = "1.0.57"
-tokio = { version = "1.0", features = ["full"] }
-tower-http = { version = "0.5.1", features = ["cors"] }
+axum-extra = "0.10.0"
+prost = "0.13"
+thiserror = "2.0.11"
+tokio = { version = "1.43.0", features = ["full"] }
+tower-http = { version = "0.6.2", features = ["cors"] }
 
 [build-dependencies]
 axum-connect-build = { path = "../axum-connect-build" }

--- a/axum-connect/Cargo.toml
+++ b/axum-connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-connect"
-version = "0.4.2"
+version = "0.5.1"
 authors = ["Alec Thilenius <alec@thilenius.com>"]
 edition = "2021"
 categories = [
@@ -15,14 +15,14 @@ readme = "../README.md"
 repository = "https://github.com/AThilenius/axum-connect"
 
 [dependencies]
-async-trait = "0.1.64"
-axum = { version = "0.8.1", features = ["multipart"] }
+async-trait = "0.1.85"
+axum = { version = ">=0.8", features = ["multipart"] }
 axum-extra = { version = "0.10.0", optional = true }
-base64 = "0.21.5"
-futures = "0.3.26"
-pbjson = "0.6.0"
-pbjson-types = "0.6.0"
-prost = "0.12.1"
+base64 = "0.22.1"
+futures = "0.3.31"
+pbjson = "0.7.0"
+pbjson-types = "0.7.0"
+prost = ">=0.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_qs = "0.12.0"
+serde_qs = "0.13.0"


### PR DESCRIPTION
@liskaant Any chance you know of some way to decouple the Axum and Prost versions from downstream? I'm 90% sure it  doesn't even make logical sense to decouple them, but sure is a pain point.