### PR TITLE
refactor: response encoding v2

### DIFF
--- a/axum-connect/Cargo.toml
+++ b/axum-connect/Cargo.toml
@@ -15,7 +15,6 @@ readme = "../README.md"
 repository = "https://github.com/AThilenius/axum-connect"
 
 [dependencies]
-async-stream = "0.3.5"
 async-trait = "0.1.64"
 axum = { version = "0.8.1", features = ["multipart"] }
 axum-extra = { version = "0.10.0", optional = true }

--- a/axum-connect/src/handler/handler_stream.rs
+++ b/axum-connect/src/handler/handler_stream.rs
@@ -1,12 +1,15 @@
 use std::pin::Pin;
 
-use async_stream::stream;
-use axum::{body::Body, http::Request, response::Response};
+use axum::body::Body;
+use axum::http::Request;
+use axum::response::Response;
 use futures::{Future, Stream, StreamExt};
 use prost::Message;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 
-use crate::{error::RpcIntoError, parts::RpcFromRequestParts, response::RpcIntoResponse};
+use crate::parts::RpcFromRequestParts;
+use crate::response::RpcIntoResponse;
 
 use super::codec::{decode_check_headers, decode_request_payload, ReqResInto, ResponseEncoder};
 
@@ -23,66 +26,6 @@ pub trait RpcHandlerStream<TMReq, TMRes, TUid, TState>:
 //      - [0-9a-z]*!"-bin" ASCII value
 //      - [0-9a-z]*-bin" (base64 encoded binary)
 // TODO: Allow response to send back both leading and trailing metadata.
-// This is here because writing Rust macros sucks a**. So I uncomment this when I'm trying to modify
-// the below macro.
-// #[allow(unused_parens, non_snake_case, unused_mut)]
-// impl<TMReq, TMRes, TInto, TFnItem, TFnFut, TFn, TState, T1>
-//     RpcHandlerStream<TMReq, TMRes, (T1, TMReq), TState> for TFn
-// where
-//     TMReq: Message + DeserializeOwned + Default + Send + 'static,
-//     TMRes: Message + Serialize + Send + 'static,
-//     TInto: RpcIntoResponse<TMRes>,
-//     TFnItem: Stream<Item = TInto> + Send + Sized + 'static,
-//     TFnFut: Future<Output = TFnItem> + Send + Sync,
-//     TFn: FnOnce(T1, TMReq) -> TFnFut + Clone + Send + Sync + 'static,
-//     TState: Send + Sync + 'static,
-//     T1: RpcFromRequestParts<TMRes, TState> + Send,
-// {
-//     type Future = Pin<Box<dyn Future<Output = Response> + Send>>;
-
-//     fn call(self, req: Request<Body>, state: TState) -> Self::Future {
-//         Box::pin(async move {
-//             let (mut parts, body) = req.into_parts();
-
-//             let ReqResInto { binary } = match decode_check_headers(&mut parts, true) {
-//                 Ok(binary) => binary,
-//                 Err(e) => return e,
-//             };
-
-//             let state = &state;
-
-//             let t1 = match T1::rpc_from_request_parts(&mut parts, state).await {
-//                 Ok(value) => value,
-//                 Err(e) => {
-//                     return ResponseEncoder::empty(true, binary)
-//                         .err(e.rpc_into_error())
-//                         .encode_response();
-//                 }
-//             };
-
-//             let req = Request::from_parts(parts, body);
-
-//             let proto_req: TMReq = match decode_request_payload(req, state, binary, true).await {
-//                 Ok(value) => value,
-//                 Err(e) => return e,
-//             };
-
-//             let mut res = Box::pin(self(t1, proto_req).await);
-
-//             let res = stream! {
-//                 while let Some(item) = res.next().await {
-//                     yield Ok(item.rpc_into_response()?);
-//                 }
-//             };
-//
-//             // EndStreamResponse, see: https://connect.build/docs/protocol/#error-end-stream
-//             // TODO: Support returning trailers (they would need to bundle in the error type).
-//             ResponseEncoder::<TMRes>::new(true, binary)
-//                 .stream(res)
-//                 .encode_response()
-//         })
-//     }
-// }
 
 macro_rules! impl_handler {
     (
@@ -118,10 +61,8 @@ macro_rules! impl_handler {
                     $(
                     let $ty = match $ty::rpc_from_request_parts(&mut parts, state).await {
                         Ok(value) => value,
-                        Err(e) => {
-                            return ResponseEncoder::empty(true, binary)
-                                .err(e.rpc_into_error())
-                                .encode_response();
+                        Err(error) => {
+                            return ResponseEncoder::error(error, true, binary).encode_response();
                         }
                     };
                     )*
@@ -133,18 +74,9 @@ macro_rules! impl_handler {
                         Err(e) => return e,
                     };
 
-                    let mut res = Box::pin(self($($ty,)* proto_req).await);
-
-                    let res = stream! {
-                        while let Some(item) = res.next().await {
-                            yield Ok(item.rpc_into_response()?);
-                        }
-                    };
-
                     // TODO: Support returning trailers (they would need to bundle in the error type).
-                    ResponseEncoder::<TMRes>::new(true, binary)
-                        .stream(res)
-                        .encode_response()
+                    let mut stream = self($($ty,)* proto_req).await.map(RpcIntoResponse::rpc_into_response);
+                    ResponseEncoder::<TMRes>::stream(stream.boxed(), binary).encode_response()
                 })
             }
         }


### PR DESCRIPTION
Continuation of #14. This one uses an enum for the "type of content". It did eliminate the weird edge cases that were technically valid but completely useless.