### PR TITLE
feat: remove async_trait

### DIFF
--- a/axum-connect/Cargo.toml
+++ b/axum-connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-connect"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Alec Thilenius <alec@thilenius.com>"]
 edition = "2021"
 categories = [
@@ -13,9 +13,10 @@ keywords = ["rpc", "axum", "protobuf", "connect"]
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
 repository = "https://github.com/AThilenius/axum-connect"
+rust-version = "1.82"
+
 
 [dependencies]
-async-trait = "0.1.85"
 axum = { version = ">=0.8", features = ["multipart"] }
 axum-extra = { version = "0.10.0", optional = true }
 base64 = "0.22.1"


### PR DESCRIPTION
1. remove async_trait
2. add minimal rust version require to 1.82
3. bump version to 0.6.0

If we can remove `async_trait`, user don't need to use `async_trait` when they impl `RpcFromRequestParts`.